### PR TITLE
chore: support JSDoc imports

### DIFF
--- a/.changeset/jsdoc-import-tag-rules.md
+++ b/.changeset/jsdoc-import-tag-rules.md
@@ -1,0 +1,5 @@
+---
+"eslint-config-webpack": minor
+---
+
+Add `webpack/prefer-import-tag`, `webpack/no-duplicate-import-tag` and `webpack/no-unused-import-tag`, which hold JSDoc type imports to a single `@import` per module with no unused bindings.

--- a/plugins/webpack/index.js
+++ b/plugins/webpack/index.js
@@ -1,5 +1,8 @@
 import { createRequire } from "node:module";
 import { allExtensions } from "../../configs/utils/extensions.js";
+import { rule as noDuplicateImportTag } from "./rules/no-duplicate-import-tag.js";
+import { rule as noUnusedImportTag } from "./rules/no-unused-import-tag.js";
+import { rule as preferImportTag } from "./rules/prefer-import-tag.js";
 import { rule as requireLicenseComment } from "./rules/require-license-comment.js";
 
 const require = createRequire(import.meta.url);
@@ -7,6 +10,9 @@ const require = createRequire(import.meta.url);
 const { version } = require("../../package.json");
 
 const rules = {
+	"no-duplicate-import-tag": noDuplicateImportTag,
+	"no-unused-import-tag": noUnusedImportTag,
+	"prefer-import-tag": preferImportTag,
 	"require-license-comment": requireLicenseComment,
 };
 

--- a/plugins/webpack/rules/no-duplicate-import-tag.js
+++ b/plugins/webpack/rules/no-duplicate-import-tag.js
@@ -1,0 +1,83 @@
+import { collectImportTags } from "../utils/import-tags.js";
+
+/** @typedef {import("../utils/import-tags.js").ImportTag} ImportTag */
+
+/**
+ * Whether two tags could be written as one import statement. A namespace binding
+ * cannot sit next to named bindings, and one statement carries at most one head.
+ * @param {ImportTag} first the earlier tag
+ * @param {ImportTag} second the later tag
+ * @returns {boolean} true when they can be folded together
+ */
+const isMergeable = (first, second) => {
+	const heads = /** @type {ImportTag[]} */ (
+		[first, second].filter((tag) => tag.head !== undefined)
+	);
+
+	if (
+		heads.length === 2 &&
+		/** @type {NonNullable<ImportTag["head"]>} */ (heads[0].head).local !==
+			/** @type {NonNullable<ImportTag["head"]>} */ (heads[1].head).local
+	) {
+		return false;
+	}
+
+	return (
+		!heads.some((tag) => tag.namespace) ||
+		first.named.length + second.named.length === 0
+	);
+};
+
+/**
+ * @type {import("eslint").Rule.RuleModule} rule rule
+ */
+export const rule = {
+	create(context) {
+		const { sourceCode } = context;
+
+		return {
+			"Program:exit"() {
+				/** @type {Map<string, ImportTag>} */
+				const seen = new Map();
+
+				for (const tag of collectImportTags(sourceCode)) {
+					const first = seen.get(tag.moduleRequest);
+
+					if (first === undefined) {
+						seen.set(tag.moduleRequest, tag);
+						continue;
+					}
+
+					if (!isMergeable(first, tag)) {
+						continue;
+					}
+
+					context.report({
+						loc: {
+							start: sourceCode.getLocFromIndex(tag.start),
+							end: sourceCode.getLocFromIndex(tag.end),
+						},
+						messageId: "duplicateImportTag",
+						data: {
+							module: tag.moduleRequest,
+							line: String(sourceCode.getLocFromIndex(first.start).line),
+						},
+					});
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: "Stylistic Issues",
+			description: "Require one `@import` per module in a file",
+			recommended: true,
+		},
+		messages: {
+			duplicateImportTag:
+				'"{{module}}" is already imported on line {{line}}; fold this `@import` into that one.',
+		},
+		schema: [],
+		type: "suggestion",
+	},
+};

--- a/plugins/webpack/rules/no-unused-import-tag.js
+++ b/plugins/webpack/rules/no-unused-import-tag.js
@@ -1,0 +1,192 @@
+import { collectImportTags } from "../utils/import-tags.js";
+
+/** @typedef {import("eslint").Rule.ReportFixer} ReportFixer */
+/** @typedef {import("eslint").SourceCode} SourceCode */
+/** @typedef {import("../utils/import-tags.js").ImportBinding} ImportBinding */
+/** @typedef {import("../utils/import-tags.js").ImportTag} ImportTag */
+
+/**
+ * The source with every `@import` tag blanked out, so one import can never keep
+ * another alive. Blanks keep the length, so offsets still address the original.
+ * @param {string} text the whole source
+ * @param {ImportTag[]} tags every `@import` tag in it
+ * @returns {string} the haystack a binding's uses are looked for in
+ */
+const buildHaystack = (text, tags) => {
+	let haystack = text;
+
+	for (const tag of tags) {
+		haystack =
+			haystack.slice(0, tag.start) +
+			" ".repeat(tag.end - tag.start) +
+			haystack.slice(tag.end);
+	}
+
+	return haystack;
+};
+
+/**
+ * @param {string} text the whole source
+ * @param {number} index an offset inside the line
+ * @returns {[number, number]} the line's range, the line break included
+ */
+const lineRangeAt = (text, index) => {
+	const start = text.lastIndexOf("\n", index - 1) + 1;
+	const lineBreak = text.indexOf("\n", index);
+
+	return [start, lineBreak === -1 ? text.length : lineBreak + 1];
+};
+
+/**
+ * Whether the tag is the only tag of a comment that owns its line — the one shape
+ * that can be removed outright.
+ * @param {string} text the whole source
+ * @param {ImportTag} tag the tag to test
+ * @returns {[number, number] | null} the range to remove, or null when unsure
+ */
+const removableCommentRange = (text, tag) => {
+	const range = /** @type {[number, number]} */ (tag.comment.range);
+
+	if (text.slice(range[0], tag.start).replace(/[/*\s]/g, "") !== "") {
+		return null;
+	}
+
+	if (/@\w/.test(text.slice(tag.end, range[1]))) {
+		return null;
+	}
+
+	const [start, end] = lineRangeAt(text, range[0]);
+	const outside =
+		text.slice(start, range[0]) +
+		text.slice(range[1], end).replace(/\r?\n$/, "");
+
+	return outside.trim() === "" ? [start, end] : null;
+};
+
+/**
+ * @param {SourceCode} sourceCode source being linted
+ * @param {ImportTag} tag the tag the binding belongs to
+ * @param {ImportBinding} binding the unused binding
+ * @param {number} bindingCount how many bindings the tag declares
+ * @returns {ReportFixer | null} a fixer, or null when the edit is not obvious
+ */
+const buildFixer = (sourceCode, tag, binding, bindingCount) => {
+	const text = sourceCode.getText();
+
+	if (bindingCount === 1) {
+		const range = removableCommentRange(text, tag);
+
+		return range === null ? null : (fixer) => fixer.removeRange(range);
+	}
+
+	// Only a named binding can be taken out on its own; dropping the head would
+	// leave a dangling comma the shapes below do not cover
+	if (binding === tag.head) {
+		return null;
+	}
+
+	if (text.slice(tag.start, tag.end).includes("\n")) {
+		// The wrapped form puts one binding per line, so the line goes with it
+		const range = lineRangeAt(text, binding.start);
+		const rest =
+			text.slice(range[0], binding.start) + text.slice(binding.end, range[1]);
+
+		if (!/^[\s*,]*$/.test(rest)) {
+			return null;
+		}
+
+		// Taking the last binding away would strand the comma the one before it ends
+		// with, which `trailingComma: "none"` does not allow
+		const previous = tag.named
+			.filter((other) => other.end <= binding.start)
+			.sort((one, another) => another.end - one.end)[0];
+		const strandedComma =
+			previous !== undefined &&
+			!tag.named.some((other) => other.start >= binding.end)
+				? text.indexOf(",", previous.end)
+				: -1;
+
+		return strandedComma === -1 || strandedComma >= binding.start
+			? (fixer) => fixer.removeRange(range)
+			: (fixer) => [
+					fixer.removeRange([strandedComma, strandedComma + 1]),
+					fixer.removeRange(range),
+			  ];
+	}
+
+	// `{ A, B }` on one line: the binding leaves with the comma that separates it
+	const after = /^[ \t]*,[ \t]*/.exec(text.slice(binding.end));
+
+	if (after !== null) {
+		return (fixer) =>
+			fixer.removeRange([binding.start, binding.end + after[0].length]);
+	}
+
+	const before = /[ \t]*,[ \t]*$/.exec(text.slice(tag.start, binding.start));
+
+	return before === null
+		? null
+		: (fixer) =>
+				fixer.removeRange([binding.start - before[0].length, binding.end]);
+};
+
+/**
+ * @type {import("eslint").Rule.RuleModule} rule rule
+ */
+export const rule = {
+	create(context) {
+		const { sourceCode } = context;
+
+		return {
+			"Program:exit"() {
+				const tags = collectImportTags(sourceCode);
+
+				if (tags.length === 0) {
+					return;
+				}
+
+				const haystack = buildHaystack(sourceCode.getText(), tags);
+
+				for (const tag of tags) {
+					const bindings = [
+						...(tag.head === undefined ? [] : [tag.head]),
+						...tag.named,
+					];
+
+					for (const binding of bindings) {
+						const used = new RegExp(
+							`(?<![\\w$])${binding.local.replace(/\$/g, "\\$")}(?![\\w$])`,
+						).test(haystack);
+
+						if (used) {
+							continue;
+						}
+
+						context.report({
+							loc: {
+								start: sourceCode.getLocFromIndex(binding.start),
+								end: sourceCode.getLocFromIndex(binding.end),
+							},
+							messageId: "unusedImportTag",
+							data: { name: binding.local },
+							fix: buildFixer(sourceCode, tag, binding, bindings.length),
+						});
+					}
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: "Stylistic Issues",
+			description: "Require every `@import` binding to be referenced",
+			recommended: true,
+		},
+		fixable: "code",
+		messages: {
+			unusedImportTag: "`{{name}}` is imported but never referenced.",
+		},
+		schema: [],
+		type: "suggestion",
+	},
+};

--- a/plugins/webpack/rules/prefer-import-tag.js
+++ b/plugins/webpack/rules/prefer-import-tag.js
@@ -1,0 +1,88 @@
+import { stripLineMarkers } from "../utils/import-tags.js";
+
+// A `@typedef` that is nothing but an import — `{import("m")}` or `{import("m").Name}`
+// — and carries no description. Anything richer (a generic instantiation, an indexed
+// access, an intersection) cannot be written as `@import`, so it is left alone.
+const PLAIN_IMPORT_TYPEDEF =
+	/@typedef[ \t]*\{[ \t]*import\((["'])([^"']+)\1\)(?:\.([A-Za-z_$][\w$]*))?[ \t]*\}[ \t]+([A-Za-z_$][\w$]*)[ \t]*(?=\r?\n|$)/g;
+
+/**
+ * @param {string} moduleRequest module the type comes from
+ * @param {string | undefined} exportName named export, or undefined for the whole module
+ * @param {string} alias local name the type is bound to
+ * @returns {string} the equivalent `@import` comment
+ */
+const buildImportComment = (moduleRequest, exportName, alias) => {
+	const binding =
+		exportName === undefined
+			? alias
+			: `{ ${exportName === alias ? alias : `${exportName} as ${alias}`} }`;
+
+	return `/** @import ${binding} from ${JSON.stringify(moduleRequest)} */`;
+};
+
+/**
+ * @type {import("eslint").Rule.RuleModule} rule rule
+ */
+export const rule = {
+	create(context) {
+		const { sourceCode } = context;
+
+		return {
+			"Program:exit"() {
+				for (const comment of sourceCode.getAllComments()) {
+					if (comment.type !== "Block" || !comment.value.startsWith("*")) {
+						continue;
+					}
+
+					const range = /** @type {[number, number]} */ (comment.range);
+					const body = stripLineMarkers(comment.value);
+
+					PLAIN_IMPORT_TYPEDEF.lastIndex = 0;
+
+					let match;
+
+					while ((match = PLAIN_IMPORT_TYPEDEF.exec(body)) !== null) {
+						const [text, , moduleRequest, exportName, alias] = match;
+						const start = range[0] + 2 + match.index;
+						// Only a comment holding this tag and nothing else can be swapped
+						// in place; lifting one tag out of a block is left to the author
+						const isWholeComment =
+							!comment.value.includes("\n") && body.trim() === text.trim();
+
+						context.report({
+							loc: {
+								start: sourceCode.getLocFromIndex(start),
+								end: sourceCode.getLocFromIndex(start + text.length),
+							},
+							messageId: "preferImportTag",
+							data: { alias },
+							fix: isWholeComment
+								? (fixer) =>
+										fixer.replaceTextRange(
+											range,
+											buildImportComment(moduleRequest, exportName, alias),
+										)
+								: null,
+						});
+					}
+				}
+			},
+		};
+	},
+	meta: {
+		docs: {
+			category: "Stylistic Issues",
+			description:
+				"Require `@import` rather than a `@typedef` that only aliases an `import()`",
+			recommended: true,
+		},
+		fixable: "code",
+		messages: {
+			preferImportTag:
+				"`{{alias}}` aliases an `import()`; declare it with `@import` instead of `@typedef`.",
+		},
+		schema: [],
+		type: "suggestion",
+	},
+};

--- a/plugins/webpack/utils/import-tags.js
+++ b/plugins/webpack/utils/import-tags.js
@@ -1,0 +1,135 @@
+/** @typedef {import("eslint").SourceCode} SourceCode */
+/** @typedef {import("estree").Comment} Comment */
+
+/**
+ * @typedef {object} ImportBinding
+ * @property {string} text binding as written, e.g. `Foo` or `Foo as Bar`
+ * @property {string} local name the binding introduces in the file
+ * @property {number} start absolute offset of the binding in the source
+ * @property {number} end absolute offset just past the binding
+ */
+
+/**
+ * @typedef {object} ImportTag
+ * @property {Comment} comment JSDoc comment the tag is written in
+ * @property {string} moduleRequest module the types are imported from
+ * @property {ImportBinding | undefined} head default or `* as ns` binding, when present
+ * @property {boolean} namespace whether `head` is a `* as ns` binding
+ * @property {ImportBinding[]} named bindings inside the braces
+ * @property {number} start absolute offset of `@import`
+ * @property {number} end absolute offset just past the module string
+ */
+
+const IMPORT_TAG = /@import[ \t]+([\s\S]*?)[ \t]+from[ \t]+(["'])([^"']+)\2/g;
+const NAMESPACE_BINDING = /\*[ \t\n]*as[ \t\n]+([A-Za-z_$][\w$]*)/;
+const DEFAULT_BINDING = /[A-Za-z_$][\w$]*/;
+
+/**
+ * Blanks out the `*` opening each JSDoc line, keeping every offset intact so
+ * matches on the result still address the original source.
+ * @param {string} text raw comment body
+ * @returns {string} the body with its line markers replaced by spaces
+ */
+export const stripLineMarkers = (text) =>
+	text.replace(/^[ \t]*\*/gm, (marker) => " ".repeat(marker.length));
+
+/**
+ * @param {string} binding binding as written, `Name` or `Name as Alias`
+ * @returns {string} the local name it introduces
+ */
+export const localNameOf = (binding) => {
+	const parts = binding.split(/[ \t\n]+as[ \t\n]+/);
+	return parts[parts.length - 1].trim();
+};
+
+/**
+ * @param {string} inner text between the braces of a named-import clause
+ * @param {number} innerStart absolute offset of that text
+ * @returns {ImportBinding[]} one entry per binding
+ */
+const parseNamedBindings = (inner, innerStart) => {
+	/** @type {ImportBinding[]} */
+	const bindings = [];
+	let offset = 0;
+
+	for (const part of inner.split(",")) {
+		const text = part.trim();
+
+		if (text !== "") {
+			const start = innerStart + offset + part.indexOf(text);
+
+			bindings.push({
+				text,
+				local: localNameOf(text),
+				start,
+				end: start + text.length,
+			});
+		}
+
+		offset += part.length + 1;
+	}
+
+	return bindings;
+};
+
+/**
+ * Reads every `@import` tag of one JSDoc comment.
+ * @param {Comment} comment the comment to read
+ * @returns {ImportTag[]} the tags it holds, in source order
+ */
+export const parseImportTags = (comment) => {
+	if (comment.type !== "Block" || !comment.value.startsWith("*")) {
+		return [];
+	}
+
+	const range = /** @type {[number, number]} */ (comment.range);
+	// `/*` sits before the value, so an index into it is `range[0] + 2` in the source
+	const base = range[0] + 2;
+	const body = stripLineMarkers(comment.value);
+	/** @type {ImportTag[]} */
+	const tags = [];
+
+	IMPORT_TAG.lastIndex = 0;
+
+	let match;
+
+	while ((match = IMPORT_TAG.exec(body)) !== null) {
+		const [text, clause, , moduleRequest] = match;
+		const clauseStart = base + match.index + text.indexOf(clause);
+		const braced = /\{([^}]*)\}/.exec(clause);
+		const named =
+			braced === null
+				? []
+				: parseNamedBindings(braced[1], clauseStart + braced.index + 1);
+		const outer = braced === null ? clause : clause.slice(0, braced.index);
+		const namespaced = NAMESPACE_BINDING.exec(outer);
+		const head = namespaced === null ? DEFAULT_BINDING.exec(outer) : namespaced;
+
+		tags.push({
+			comment,
+			moduleRequest,
+			head:
+				head === null
+					? undefined
+					: {
+							text: head[0],
+							local: namespaced === null ? head[0] : head[1],
+							start: clauseStart + head.index,
+							end: clauseStart + head.index + head[0].length,
+					  },
+			namespace: namespaced !== null,
+			named,
+			start: base + match.index,
+			end: base + match.index + text.length,
+		});
+	}
+
+	return tags;
+};
+
+/**
+ * @param {SourceCode} sourceCode source being linted
+ * @returns {ImportTag[]} every `@import` tag in the file, in source order
+ */
+export const collectImportTags = (sourceCode) =>
+	sourceCode.getAllComments().flatMap((comment) => parseImportTags(comment));

--- a/validation/webpack/file.js
+++ b/validation/webpack/file.js
@@ -15,3 +15,15 @@ function sum(a, b) {
 }
 
 sum(1, 2);
+
+/** @import { Buffer as NodeBuffer } from "node:buffer" */
+
+/**
+ * @param {NodeBuffer} buffer buffer
+ * @returns {number} its length
+ */
+function size(buffer) {
+	return buffer.length;
+}
+
+size(Buffer.from("webpack"));


### PR DESCRIPTION
Ref: https://github.com/webpack/webpack/pull/21790

Needs to be a custom extension rather than an existing rule (https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/prefer-import-tag.md) since that rule:
- Doesn't follow our formatting guidelines
- Doesn't _replace_ typedefs, it only appends new ones